### PR TITLE
[BUGFIX] Avoid undefined method '[]=' for nil:NilClass on Mac OS X

### DIFF
--- a/attributes/automatic.rb
+++ b/attributes/automatic.rb
@@ -1,4 +1,5 @@
 unless ::Chef::Config[:pci_devices_disabled]
+  automatic_attrs['pci'] = Mash.new if automatic_attrs['pci'].nil?
   # Provide information about PCI devices (vendor_id, device_id, class_id, ...)
   automatic_attrs['pci']['devices'] = ::PCI.devices(node)
 


### PR DESCRIPTION
Fix the following issue on Mac OS X:

Recipe Compile Error in /var/chef/cache/cookbooks/pci/attributes/automatic.rb

NoMethodError
-------------
undefined method `[]=' for nil:NilClass